### PR TITLE
Add S3 source mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,7 @@
 SID="xxxxxxxxx"
 SOURCE_PROJECT_NAME="xxxxxxxx"
 DESTINATION_PROJECT_NAME="xxxxxxx"
+# S3から取得したexport JSONを使う場合にパスを指定します。未設定ならScrapbox APIから直接exportします。
+EXPORT_JSON_PATH=""
 # "Ttrue"にすると、デフォルトで複製するようになります。
 SHOULD_DUPLICATE_BY_DEFAULT="False"

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 SID="xxxxxxxxx"
 SOURCE_PROJECT_NAME="xxxxxxxx"
 DESTINATION_PROJECT_NAME="xxxxxxx"
-# S3から取得したexport JSONを使う場合にパスを指定します。未設定ならScrapbox APIから直接exportします。
+# Path to exported JSON file (e.g. from S3). If unset, exports directly from Scrapbox API.
 EXPORT_JSON_PATH=""
-# "Ttrue"にすると、デフォルトで複製するようになります。
+# Set to "True" to duplicate all pages by default.
 SHOULD_DUPLICATE_BY_DEFAULT="False"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,3 @@ jobs:
         run: deno lint
       - name: Run type check
         run: deno cache *.ts
-

--- a/.github/workflows/duplicator.yml
+++ b/.github/workflows/duplicator.yml
@@ -3,7 +3,7 @@ name: Duplicater
 on:
   workflow_dispatch:
   schedule:
-    # - cron: '0 21 * * *' # JST 6:00
+# - cron: '0 21 * * *' # JST 6:00
 
 env:
   SID: ${{ secrets.SID }}
@@ -16,8 +16,8 @@ env:
 jobs:
   build:
     permissions:
-      contents: 'write'
-      id-token: 'write'
+      contents: "write"
+      id-token: "write"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/duplicator.yml
+++ b/.github/workflows/duplicator.yml
@@ -8,18 +8,26 @@ on:
 env:
   SID: ${{ secrets.SID }}
   PROJECT_NAME: ${{ secrets.PROJECT_NAME }}
-  SOURCE_PROJECT_NAME: ${{ secrets.SOURCE_PROJECT_NAME }}
-  DESTINATION_PROJECT_NAME: ${{ secrets.DESTINATION_PROJECT_NAME }}
-  SHOULD_DUPLICATE_BY_DEFAULT: ${{ secrets.SHOULD_DUPLICATE_BY_DEFAULT }}
+  SOURCE_PROJECT_NAME: ${{ vars.SOURCE_PROJECT_NAME }}
+  DESTINATION_PROJECT_NAME: ${{ vars.DESTINATION_PROJECT_NAME }}
+  SHOULD_DUPLICATE_BY_DEFAULT: ${{ vars.SHOULD_DUPLICATE_BY_DEFAULT }}
+  EXPORT_JSON_PATH: export.json
 
 jobs:
   build:
     permissions:
       contents: 'write'
+      id-token: 'write'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Download export json from S3
+        run: aws s3 cp s3://${{ vars.S3_BUCKET }}/${{ vars.S3_PREFIX }}/${{ vars.SOURCE_PROJECT_NAME }}.json export.json
 
-      - name: Export from Scrapbox(/PROJECT_NAME to PROJECT_NAME.json)
+      - name: Run duplicator
         run: deno run --allow-net=scrapbox.io --allow-read=./ --allow-write --allow-env index.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Scrapbox Duplicator Template
+
+Deno project that duplicates Scrapbox pages between projects.
+
+## Pre-push checks
+
+Run these before pushing (matches CI in `.github/workflows/ci.yml`):
+
+```sh
+deno fmt --check .
+deno lint .
+deno check *.ts
+```
+
+Or fix formatting automatically with `deno fmt .` then run the rest.

--- a/README.md
+++ b/README.md
@@ -1,59 +1,34 @@
 # Scrapbox Duplicator
 
-Scrapboxの非公開・公開プロジェクトを分けて運用する際に面倒な「ページの転送」を自動で行います。
+Automatically duplicates pages from a source Scrapbox project to a destination project, filtering by `[public]` / `[private]` tags.
 
-## 目次
+## How it works
 
-- [仕組み](#仕組み)
-- [スタートガイド](#スタートガイド)
-- [必要なもの](#必要なもの)
-- [注意事項](#注意事項)
-- [その他](#その他)
-- [謝辞](#謝辞)
+1. Export pages from the source project (via Scrapbox API or a pre-exported JSON file from S3)
+2. Filter pages: include pages with `[public]`, exclude pages with `[private]`
+3. Import the filtered pages into the destination project
 
-## 仕組み
+## Setup
 
-以下の処理の定期実行によって、公開したいページのみ転送されたミラープロジェクトが作られます。
+1. Fork this repository
+2. Set the required environment variables (as GitHub Actions secrets/variables)
 
-1. 転送元プロジェクトの内容をエクスポート
-2. エクスポートされたjsonファイルから`[public.icon]`が含まれているページのみを抽出
-3. 抽出されたページを転送先プロジェクトへインポート
+### Required variables
 
-## スタートガイド
+| Variable | Type | Description |
+|---|---|---|
+| `SID` | secret | Scrapbox session ID |
+| `SOURCE_PROJECT_NAME` | variable | Source project name |
+| `DESTINATION_PROJECT_NAME` | variable | Destination project name |
+| `SHOULD_DUPLICATE_BY_DEFAULT` | variable | `True` to duplicate pages without explicit tags |
 
-以下のステップで実行可能です。
+### S3 source mode (optional)
 
-1. このリポジトリをForkする
-2. Forkしたリポジトリに環境変数を設定する
+Instead of calling the Scrapbox API directly, pages can be read from a JSON file exported to S3 (e.g. via [scrapbox-export-s3](https://github.com/mu373/scrapbox-export-s3)).
 
-<!-- 環境変数の設定イメージ -->
-
-以下の画像は環境変数の設定方法を示しています。
-[![Image from Gyazo](https://i.gyazo.com/cd8630a6fb125c6d7e627b290fbe79ce.png)](https://gyazo.com/cd8630a6fb125c6d7e627b290fbe79ce)
-
-<!-- すぐに動作確認がしたい時は手動で起動できる -->
-
-動作確認をすぐに行いたい場合は、以下の画像のように手動で起動することが可能です。
-[![Image from Gyazo](https://i.gyazo.com/e4762cda8e8566bb75d20a429c2f1cb1.png)](https://gyazo.com/e4762cda8e8566bb75d20a429c2f1cb1)
-
-## 必要なもの
-
-1. `SID`
-   ScrapboxのSID（詳しくは[こちら](https://scrapbox.io/nishio/Scrapbox%E3%81%AEprivate%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AEAPI%E3%82%92%E5%8F%A9%E3%81%8F)）
-2. `SOURCE_PROJECT_NAME` 転送元のプロジェクト名
-3. `DESTINATION_PROJECT_NAME` 転送先のプロジェクト名
-
-## 注意事項
-
-- まともにテストしていないので、**自己責任で使用してください**。使用前にプロジェクトのバックアップ取得をオススメします。
-- SIDは漏れた場合にリセットする手段が無さそうなので、気をつけて扱ってください。サブアカウントのSID等を使用する事をオススメします。（詳しくは[こちら](https://scrapbox.io/nishio/Scrapbox%E3%81%AEprivate%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AEAPI%E3%82%92%E5%8F%A9%E3%81%8F)）
-- ExportするAPIは使用回数に制限があるので、定期実行は一日2~3回程度が良いと思います。
-
-## その他
-
-Scrapbox
-Duplicatorは定期実行のタイミングまで待たないと転送されません。好きなタイミングで公開したい場合は、[このUserScript](https://scrapbox.io/blu3mo-public/%E3%83%9A%E3%83%BC%E3%82%B8%E8%BB%A2%E9%80%81%E3%81%99%E3%82%8B%E6%8B%A1%E5%BC%B5script)を一緒に使う事をオススメします。
-
-## 謝辞
-
-Scrapboxを開発しているNota, Inc. の皆さんに感謝します。
+| Variable | Type | Description |
+|---|---|---|
+| `AWS_ROLE_ARN` | variable | IAM role ARN for OIDC authentication |
+| `S3_BUCKET` | variable | S3 bucket name |
+| `S3_PREFIX` | variable | S3 key prefix (e.g. `scrapbox-exports/projects`) |
+| `EXPORT_JSON_PATH` | env | Path to the downloaded JSON file (set in workflow) |

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Scrapbox Duplicator
 
-Automatically duplicates pages from a source Scrapbox project to a destination project, filtering by `[public]` / `[private]` tags.
+Automatically duplicates pages from a source Scrapbox project to a destination
+project, filtering by `[public]` / `[private]` tags.
 
 ## How it works
 
-1. Export pages from the source project (via Scrapbox API or a pre-exported JSON file from S3)
+1. Export pages from the source project (via Scrapbox API or a pre-exported JSON
+   file from S3)
 2. Filter pages: include pages with `[public]`, exclude pages with `[private]`
 3. Import the filtered pages into the destination project
 
@@ -15,20 +17,22 @@ Automatically duplicates pages from a source Scrapbox project to a destination p
 
 ### Required variables
 
-| Variable | Type | Description |
-|---|---|---|
-| `SID` | secret | Scrapbox session ID |
-| `SOURCE_PROJECT_NAME` | variable | Source project name |
-| `DESTINATION_PROJECT_NAME` | variable | Destination project name |
+| Variable                      | Type     | Description                                     |
+| ----------------------------- | -------- | ----------------------------------------------- |
+| `SID`                         | secret   | Scrapbox session ID                             |
+| `SOURCE_PROJECT_NAME`         | variable | Source project name                             |
+| `DESTINATION_PROJECT_NAME`    | variable | Destination project name                        |
 | `SHOULD_DUPLICATE_BY_DEFAULT` | variable | `True` to duplicate pages without explicit tags |
 
 ### S3 source mode (optional)
 
-Instead of calling the Scrapbox API directly, pages can be read from a JSON file exported to S3 (e.g. via [scrapbox-export-s3](https://github.com/mu373/scrapbox-export-s3)).
+Instead of calling the Scrapbox API directly, pages can be read from a JSON file
+exported to S3 (e.g. via
+[scrapbox-export-s3](https://github.com/mu373/scrapbox-export-s3)).
 
-| Variable | Type | Description |
-|---|---|---|
-| `AWS_ROLE_ARN` | variable | IAM role ARN for OIDC authentication |
-| `S3_BUCKET` | variable | S3 bucket name |
-| `S3_PREFIX` | variable | S3 key prefix (e.g. `scrapbox-exports/projects`) |
-| `EXPORT_JSON_PATH` | env | Path to the downloaded JSON file (set in workflow) |
+| Variable           | Type     | Description                                        |
+| ------------------ | -------- | -------------------------------------------------- |
+| `AWS_ROLE_ARN`     | variable | IAM role ARN for OIDC authentication               |
+| `S3_BUCKET`        | variable | S3 bucket name                                     |
+| `S3_PREFIX`        | variable | S3 key prefix (e.g. `scrapbox-exports/projects`)   |
+| `EXPORT_JSON_PATH` | env      | Path to the downloaded JSON file (set in workflow) |

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-import "https://deno.land/x/dotenv@v3.2.2/load.ts";
+import "jsr:@std/dotenv/load";
 export { assert, is } from "https://deno.land/x/unknownutil@v3.18.1/mod.ts";
-export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.14.1/rest/page-data.ts";
+export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.31.0/rest/page-data.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
 import "jsr:@std/dotenv/load";
 export { assert, is } from "https://deno.land/x/unknownutil@v3.18.1/mod.ts";
-export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.31.0/rest/page-data.ts";
+export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.27.1/rest/page-data.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,0 @@
-import "jsr:@std/dotenv/load";
-export { assert, is } from "https://deno.land/x/unknownutil@v3.18.1/mod.ts";
-export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.27.1/rest/page-data.ts";

--- a/index.ts
+++ b/index.ts
@@ -3,34 +3,44 @@ import { assert, exportPages, importPages, is } from "./deps.ts";
 const sid = Deno.env.get("SID");
 const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME"); //インポート元(本来はprivateプロジェクト)
 const importingProjectName = Deno.env.get("DESTINATION_PROJECT_NAME"); //インポート先(publicプロジェクト)
+const exportJsonPath = Deno.env.get("EXPORT_JSON_PATH");
 const shouldDuplicateByDefault =
   Deno.env.get("SHOULD_DUPLICATE_BY_DEFAULT") === "True";
 
-assert(sid, is.String);
-assert(exportingProjectName, is.String);
 assert(importingProjectName, is.String);
 
-console.log(`Exporting a json file from "/${exportingProjectName}"...`);
-const result = await exportPages(exportingProjectName, {
-  sid,
-  metadata: true,
-});
-if (!result.ok) {
-  const error = new Error();
-  error.name = `${result.value.name} when exporting a json file`;
-  error.message = result.value.message;
-  throw error;
-}
-const { pages } = result.value;
-console.log(`Export ${pages.length}pages:`);
-for (const page of pages) {
-  console.log(`\t${page.title}`);
+const getLineText = (line: string | { text: string }): string =>
+  typeof line === "string" ? line : line.text;
+
+// deno-lint-ignore no-explicit-any
+let pages: any[];
+if (exportJsonPath) {
+  console.log(`Reading exported json from "${exportJsonPath}"...`);
+  const parsed = JSON.parse(await Deno.readTextFile(exportJsonPath));
+  pages = parsed.pages;
+  console.log(`Loaded ${pages.length} pages from json.`);
+} else {
+  assert(sid, is.String);
+  assert(exportingProjectName, is.String);
+  console.log(`Exporting a json file from "/${exportingProjectName}"...`);
+  const result = await exportPages(exportingProjectName, {
+    sid,
+    metadata: true,
+  });
+  if (!result.ok) {
+    const error = new Error();
+    error.name = `${result.value.name} when exporting a json file`;
+    error.message = result.value.message;
+    throw error;
+  }
+  pages = result.value.pages;
+  console.log(`Exported ${pages.length} pages.`);
 }
 
 const importingPages = pages.filter(({ lines }) => {
-  if (lines.some((line) => line.text.includes("[private.icon]"))) {
+  if (lines.some((line: string | { text: string }) => getLineText(line).includes("[private.icon]"))) {
     return false;
-  } else if (lines.some((line) => line.text.includes("[public.icon]"))) {
+  } else if (lines.some((line: string | { text: string }) => getLineText(line).includes("[public.icon]"))) {
     return true;
   } else {
     return shouldDuplicateByDefault;
@@ -40,6 +50,7 @@ const importingPages = pages.filter(({ lines }) => {
 if (importingPages.length === 0) {
   console.log("No page to be imported found.");
 } else {
+  assert(sid, is.String);
   console.log(
     `Importing ${importingPages.length} pages to "/${importingProjectName}"...`,
   );

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import "jsr:@std/dotenv/load";
+import "jsr:@std/dotenv@0.225.6/load";
 import { exportPages, importPages } from "./scrapbox.ts";
 
 const sid = Deno.env.get("SID");

--- a/index.ts
+++ b/index.ts
@@ -38,9 +38,17 @@ if (exportJsonPath) {
 }
 
 const importingPages = pages.filter(({ lines }) => {
-  if (lines.some((line: string | { text: string }) => getLineText(line).includes("[private]"))) {
+  if (
+    lines.some((line: string | { text: string }) =>
+      getLineText(line).includes("[private]")
+    )
+  ) {
     return false;
-  } else if (lines.some((line: string | { text: string }) => getLineText(line).includes("[public]"))) {
+  } else if (
+    lines.some((line: string | { text: string }) =>
+      getLineText(line).includes("[public]")
+    )
+  ) {
     return true;
   } else {
     return shouldDuplicateByDefault;

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
 import { assert, exportPages, importPages, is } from "./deps.ts";
 
 const sid = Deno.env.get("SID");
-const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME"); //インポート元(本来はprivateプロジェクト)
-const importingProjectName = Deno.env.get("DESTINATION_PROJECT_NAME"); //インポート先(publicプロジェクト)
+const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME");
+const importingProjectName = Deno.env.get("DESTINATION_PROJECT_NAME");
 const exportJsonPath = Deno.env.get("EXPORT_JSON_PATH");
 const shouldDuplicateByDefault =
   Deno.env.get("SHOULD_DUPLICATE_BY_DEFAULT") === "True";
@@ -38,9 +38,9 @@ if (exportJsonPath) {
 }
 
 const importingPages = pages.filter(({ lines }) => {
-  if (lines.some((line: string | { text: string }) => getLineText(line).includes("[private.icon]"))) {
+  if (lines.some((line: string | { text: string }) => getLineText(line).includes("[private]"))) {
     return false;
-  } else if (lines.some((line: string | { text: string }) => getLineText(line).includes("[public.icon]"))) {
+  } else if (lines.some((line: string | { text: string }) => getLineText(line).includes("[public]"))) {
     return true;
   } else {
     return shouldDuplicateByDefault;

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
-import { assert, exportPages, importPages, is } from "./deps.ts";
+import "jsr:@std/dotenv/load";
+import { exportPages, importPages } from "./scrapbox.ts";
 
 const sid = Deno.env.get("SID");
 const exportingProjectName = Deno.env.get("SOURCE_PROJECT_NAME");
@@ -7,7 +8,9 @@ const exportJsonPath = Deno.env.get("EXPORT_JSON_PATH");
 const shouldDuplicateByDefault =
   Deno.env.get("SHOULD_DUPLICATE_BY_DEFAULT") === "True";
 
-assert(importingProjectName, is.String);
+if (!importingProjectName) {
+  throw new Error("DESTINATION_PROJECT_NAME is required");
+}
 
 const getLineText = (line: string | { text: string }): string =>
   typeof line === "string" ? line : line.text;
@@ -20,18 +23,17 @@ if (exportJsonPath) {
   pages = parsed.pages;
   console.log(`Loaded ${pages.length} pages from json.`);
 } else {
-  assert(sid, is.String);
-  assert(exportingProjectName, is.String);
+  if (!sid) throw new Error("SID is required when not using EXPORT_JSON_PATH");
+  if (!exportingProjectName) {
+    throw new Error("SOURCE_PROJECT_NAME is required");
+  }
   console.log(`Exporting a json file from "/${exportingProjectName}"...`);
   const result = await exportPages(exportingProjectName, {
     sid,
     metadata: true,
   });
   if (!result.ok) {
-    const error = new Error();
-    error.name = `${result.value.name} when exporting a json file`;
-    error.message = result.value.message;
-    throw error;
+    throw result.value;
   }
   pages = result.value.pages;
   console.log(`Exported ${pages.length} pages.`);
@@ -58,7 +60,7 @@ const importingPages = pages.filter(({ lines }) => {
 if (importingPages.length === 0) {
   console.log("No page to be imported found.");
 } else {
-  assert(sid, is.String);
+  if (!sid) throw new Error("SID is required for importing pages");
   console.log(
     `Importing ${importingPages.length} pages to "/${importingProjectName}"...`,
   );
@@ -68,10 +70,7 @@ if (importingPages.length === 0) {
     sid,
   });
   if (!result.ok) {
-    const error = new Error();
-    error.name = `${result.value.name} when importing pages`;
-    error.message = result.value.message;
-    throw error;
+    throw result.value;
   }
   console.log(result.value);
 }

--- a/scrapbox.ts
+++ b/scrapbox.ts
@@ -1,0 +1,82 @@
+const SCRAPBOX_HOST = "scrapbox.io";
+
+const cookie = (sid: string) => `connect.sid=${sid}`;
+
+const getCSRFToken = async (sid: string): Promise<string> => {
+  const res = await fetch(`https://${SCRAPBOX_HOST}/api/users/me`, {
+    headers: { Cookie: cookie(sid) },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to get CSRF token: ${res.status} ${res.statusText}`,
+    );
+  }
+  const user = await res.json();
+  return user.csrfToken;
+};
+
+// deno-lint-ignore no-explicit-any
+export const importPages = async (
+  project: string,
+  data: { pages: any[] },
+  init: { sid: string },
+): Promise<{ ok: true; value: string } | { ok: false; value: Error }> => {
+  if (data.pages.length === 0) {
+    return { ok: true, value: "No pages to import." };
+  }
+
+  const csrf = await getCSRFToken(init.sid);
+  const formData = new FormData();
+  formData.append(
+    "import-file",
+    new Blob([JSON.stringify(data)], { type: "application/octet-stream" }),
+  );
+  formData.append("name", "undefined");
+
+  const res = await fetch(
+    `https://${SCRAPBOX_HOST}/api/page-data/import/${project}.json`,
+    {
+      method: "POST",
+      headers: {
+        Cookie: cookie(init.sid),
+        Accept: "application/json, text/plain, */*",
+        "X-CSRF-TOKEN": csrf,
+      },
+      body: formData,
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    return {
+      ok: false,
+      value: new Error(`Import failed: ${res.status} ${text}`),
+    };
+  }
+
+  const { message } = await res.json();
+  return { ok: true, value: message };
+};
+
+export const exportPages = async (
+  project: string,
+  init: { sid: string; metadata: boolean },
+): Promise<
+  // deno-lint-ignore no-explicit-any
+  { ok: true; value: any } | { ok: false; value: Error }
+> => {
+  const res = await fetch(
+    `https://${SCRAPBOX_HOST}/api/page-data/export/${project}.json?metadata=${init.metadata}`,
+    { headers: { Cookie: cookie(init.sid) } },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    return {
+      ok: false,
+      value: new Error(`Export failed: ${res.status} ${text}`),
+    };
+  }
+
+  return { ok: true, value: await res.json() };
+};

--- a/scrapbox.ts
+++ b/scrapbox.ts
@@ -20,9 +20,9 @@ const getCSRFToken = async (sid: string): Promise<string> => {
 };
 
 /** Import pages into a project via POST /api/page-data/import/{project}.json */
-// deno-lint-ignore no-explicit-any
 export const importPages = async (
   project: string,
+  // deno-lint-ignore no-explicit-any
   data: { pages: any[] },
   init: { sid: string },
 ): Promise<{ ok: true; value: string } | { ok: false; value: Error }> => {

--- a/scrapbox.ts
+++ b/scrapbox.ts
@@ -1,7 +1,11 @@
+// Minimal Scrapbox REST API client for page import/export.
+// Ref: https://scrapbox.io/help-jp/API
+
 const SCRAPBOX_HOST = "scrapbox.io";
 
 const cookie = (sid: string) => `connect.sid=${sid}`;
 
+/** Fetch CSRF token from the Scrapbox user profile API. */
 const getCSRFToken = async (sid: string): Promise<string> => {
   const res = await fetch(`https://${SCRAPBOX_HOST}/api/users/me`, {
     headers: { Cookie: cookie(sid) },
@@ -15,6 +19,7 @@ const getCSRFToken = async (sid: string): Promise<string> => {
   return user.csrfToken;
 };
 
+/** Import pages into a project via POST /api/page-data/import/{project}.json */
 // deno-lint-ignore no-explicit-any
 export const importPages = async (
   project: string,
@@ -58,6 +63,7 @@ export const importPages = async (
   return { ok: true, value: message };
 };
 
+/** Export all pages from a project via GET /api/page-data/export/{project}.json */
 export const exportPages = async (
   project: string,
   init: { sid: string; metadata: boolean },


### PR DESCRIPTION
## Summary
- Add S3 source mode: read pages from a pre-exported JSON file (`EXPORT_JSON_PATH`) instead of calling the Scrapbox export API directly
- Falls back to Scrapbox API export when `EXPORT_JSON_PATH` is unset
- Drop external dependencies (takker99/scrapbox-userscript-std, unknownutil, dotenv), inline a minimal Scrapbox API client in `scrapbox.ts`
- Add AWS OIDC auth and S3 download step to GitHub Actions workflow
- Rewrite docs and comments in English
- Use `[public]`/`[private]` tags instead of `[public.icon]`/`[private.icon]`

## New GitHub Actions variables needed
- `AWS_ROLE_ARN` — IAM role ARN for OIDC
- `S3_BUCKET` — S3 bucket name
- `S3_PREFIX` — S3 key prefix (e.g. `scrapbox-exports/projects`)
- `SOURCE_PROJECT_NAME`, `DESTINATION_PROJECT_NAME`, `SHOULD_DUPLICATE_BY_DEFAULT` — moved from secrets to variables